### PR TITLE
RCL-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,9 @@ A horizontal bar chart component for comparing values across categories.
 | `barSpacing` | `number` | `2` | Space between bars in same category |
 | `categorySpacing` | `number` | `8` | Space between categories |
 | `showGrid` | `boolean` | `true` | Show grid lines |
-| `showVerticalGrid` | `boolean` | `true` | Show vertical grid lines |
-| `showHorizontalGrid` | `boolean` | `false` | Show horizontal grid lines |
+| `showValueGrid` | `boolean` | `true` | Show value grid lines (vertical) |
+| `showBaselineAxis` | `boolean` | `true` | Show baseline axis (bottom) |
+| `showLeftAxis` | `boolean` | `true` | Show left axis |
 | `gridLineVariant` | `'solid' \| 'dashed' \| 'dotted'` | `'dashed'` | Grid line style |
 | `showValues` | `boolean` | `false` | Display values on bars |
 | `animated` | `boolean` | `true` | Enable animations |
@@ -199,6 +200,10 @@ Includes all `HorizontalBarChart` props plus:
 | `lineWidth` | `number` | `2` | Line stroke width |
 | `showLinePoints` | `boolean` | `true` | Show points on lines |
 | `linePointRadius` | `number` | `4` | Line point radius |
+| `showBaselineAxis` | `boolean` | `true` | Show baseline axis (bottom) |
+| `showLeftAxis` | `boolean` | `true` | Show left axis |
+| `showValueGrid` | `boolean` | `true` | Show value grid lines (horizontal) |
+| `showCategoryGrid` | `boolean` | `false` | Show category columns |
 
 **Additional Types:**
 
@@ -264,7 +269,7 @@ A radar/spider chart for multi-dimensional data visualization.
 | `gridLineVariant` | `'solid' \| 'dashed' \| 'dotted'` | `'dashed'` | Grid line style |
 | `dotRadius` | `number` | `3` | Data point radius |
 | `strokeWidth` | `number` | `2` | Line stroke width |
-| `fillOpacity` | `number` | `0.15` | Default fill opacity |
+| `fillOpacity` | `number` | `0.15` | Default fill opacity (overridden by legend's `fillOpacity` when provided) |
 | `showLegend` | `boolean` | `true` | Display legend |
 | `showTooltip` | `boolean` | `false` | Enable tooltips |
 | `unstyled` | `boolean` | `false` | Disable default styling |
@@ -292,6 +297,21 @@ interface RadarChartScale {
   formatter?: (value: number) => string;
 }
 ```
+
+### Bar Charts: Shared Props
+
+Both `<HorizontalBarChart />` and `<VerticalBarChart />` share a common set of props:
+
+- `legends`, `scale`, `title`, `subtitle`, `iconSrc`, `showLegend`
+- `barSpacing`, `categorySpacing`
+- `showGrid`, `showValueGrid`, `gridLineVariant`
+- `showValues`, `animated`, `animationDuration`
+- `showBaselineAxis`, `showLeftAxis`
+- `className`, `style`, `id`, `showTooltip`, `unstyled`, `classes`
+
+Notes:
+- Axis names are standardized as `showBaselineAxis` (formerly `apsis`) and `showLeftAxis` (formerly `ordinat`).
+- Radar and Pie use a unified `size` prop for square viewBox sizing.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -24,17 +24,17 @@ React Chart Lite provides a modern, minimalist approach to data visualization wi
 
 ---
 
-## ✨ Features
+## Features
 
-- **🪶 Ultra Lightweight** - Zero dependencies except React
-- **⚡ Performance First** - Optimized rendering with tree-shakable exports
-- **🎨 Fully Customizable** - CSS Modules, custom properties, and unstyled variants
-- **♿ Accessible by Design** - WCAG compliant with keyboard and screen reader support
-- **📱 Responsive** - Mobile-friendly with touch interactions
-- **🔧 TypeScript** - Full type safety with comprehensive interfaces
-- **🚀 Modern React** - Support for React 18/19 with client-side rendering
+- **Ultra Lightweight** - Zero dependencies except React
+- **Performance First** - Optimized rendering with tree-shakable exports
+- **Fully Customizable** - CSS Modules, custom properties, and unstyled variants
+- **Accessible by Design** - WCAG compliant with keyboard and screen reader support
+- **Responsive** - Mobile-friendly with touch interactions
+- **TypeScript** - Full type safety with comprehensive interfaces
+- **Modern React** - Support for React 18/19 with client-side rendering
 
-## 📊 Chart Types
+## Chart Types
 
 <table>
   <tr>
@@ -61,7 +61,7 @@ React Chart Lite provides a modern, minimalist approach to data visualization wi
 
 ---
 
-## 🚀 Quick Start
+## Quick Start
 
 ### Installation
 
@@ -120,7 +120,7 @@ function MyChart() {
 
 ---
 
-## 📚 API Reference
+## API Reference
 
 ### Components
 
@@ -153,7 +153,7 @@ A horizontal bar chart component for comparing values across categories.
 | `showTooltip` | `boolean` | `false` | Enable interactive tooltips |
 | `onBarClick` | `(bar, categoryIndex, barIndex) => void` | `undefined` | Bar click handler |
 | `unstyled` | `boolean` | `false` | Disable default styling |
-| `classes` | `Record<string, string>` | `{}` | Custom CSS classes |
+| `classes` | `Partial<{ root: string; container: string; body: string; rows: string; row: string; rowLabel: string; rowBars: string; barWrapper: string; bar: string; barValue: string; tooltip: string }>` | `{}` | Custom CSS classes |
 
 **Type Definitions:**
 
@@ -164,7 +164,7 @@ interface ChartDataItem {
 }
 
 interface ChartBar {
-  label: string;
+  label?: string;
   value: number;
   legendId: string;
   tooltip?: string;
@@ -174,6 +174,7 @@ interface ChartLegendItem {
   id: string;
   label: string;
   color: string;
+  fillOpacity?: number; // used by Radar only
 }
 
 interface ChartScale {
@@ -236,7 +237,7 @@ A pie/donut chart for displaying proportional data.
 | `showLegend` | `boolean` | `true` | Display legend |
 | `showTooltip` | `boolean` | `false` | Enable tooltips |
 | `unstyled` | `boolean` | `false` | Disable default styling |
-| `classes` | `Record<string, string>` | `{}` | Custom CSS classes |
+| `classes` | `Partial<{ root: string; container: string; square: string; svg: string; label: string; tooltip: string }>` | `{}` | Custom CSS classes |
 
 **Type Definitions:**
 
@@ -257,7 +258,7 @@ A radar/spider chart for multi-dimensional data visualization.
 |----------|------|---------|-------------|
 | `axes` | `string[]` | **required** | Axis labels |
 | `series` | `RadarChartSeries[]` | **required** | Data series |
-| `legends` | `RadarChartLegendItem[]` | **required** | Color, label, and opacity definitions |
+| `legends` | `ChartLegendItem[]` | **required** | Color, label, and opacity definitions |
 | `title` | `string` | `undefined` | Chart title |
 | `subtitle` | `string` | `undefined` | Chart subtitle |
 | `iconSrc` | `string` | `undefined` | Icon URL (44x44px) |
@@ -273,7 +274,7 @@ A radar/spider chart for multi-dimensional data visualization.
 | `showLegend` | `boolean` | `true` | Display legend |
 | `showTooltip` | `boolean` | `false` | Enable tooltips |
 | `unstyled` | `boolean` | `false` | Disable default styling |
-| `classes` | `Record<string, string>` | `{}` | Custom CSS classes |
+| `classes` | `Partial<{ root: string; container: string; svgWrap: string; square: string; svg: string; axisLabel: string; tooltip: string }>` | `{}` | Custom CSS classes |
 
 **Type Definitions:**
 
@@ -283,12 +284,7 @@ interface RadarChartSeries {
   legendId: string;
 }
 
-interface RadarChartLegendItem {
-  id: string;
-  label: string;
-  color: string;
-  fillOpacity?: number;
-}
+// Uses shared ChartLegendItem (id, label, color, optional fillOpacity)
 
 interface RadarChartScale {
   min: number;
@@ -315,7 +311,7 @@ Notes:
 
 ---
 
-## 🎨 Styling & Theming
+## Styling & Theming
 
 ### CSS Custom Properties
 
@@ -382,7 +378,7 @@ Each component exposes specific class names for granular control:
 
 ---
 
-## 🔧 Advanced Usage
+## Advanced Usage
 
 ### Custom Scale with Formatter
 
@@ -463,7 +459,7 @@ function handleBarClick(bar, categoryIndex, barIndex) {
 
 ---
 
-## ♿ Accessibility
+## Accessibility
 
 React Chart Lite follows WCAG guidelines:
 
@@ -485,7 +481,7 @@ React Chart Lite follows WCAG guidelines:
 
 ---
 
-## 📱 Examples
+## Examples
 
 ### Financial Dashboard
 
@@ -563,7 +559,7 @@ function PerformanceRadar() {
 
 ---
 
-## 🛠️ Development
+## Development
 
 ### Local Development
 
@@ -625,7 +621,7 @@ npm run type-check
 
 ---
 
-## 📦 Bundle Size
+## Bundle Size
 
 React Chart Lite is optimized for minimal bundle impact:
 
@@ -636,7 +632,7 @@ React Chart Lite is optimized for minimal bundle impact:
 
 ---
 
-## 🤝 Contributing
+## Contributing
 
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
 
@@ -649,13 +645,13 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ---
 
-## 📄 License
+## License
 
 MIT © [Ömer Faruk Gürbüz](https://github.com/omerfarukgurbuz)
 
 ---
 
-## 🔗 Links
+## Links
 
 - [Documentation](https://github.com/omerfarukgurbuz/react-chart-lite)
 - [Examples](https://github.com/omerfarukgurbuz/react-chart-lite/tree/main/examples)

--- a/examples/demo-vite/src/App.tsx
+++ b/examples/demo-vite/src/App.tsx
@@ -225,8 +225,7 @@ function App() {
               subtitle="Revenue vs Cost vs Returns with multiple trend lines"
               showLegend
               showGrid
-              showVerticalGrid
-              showHorizontalGrid
+              showValueGrid
               gridLineVariant="dashed"
               showLine
               lineSeries={testLineSeries}
@@ -235,8 +234,8 @@ function App() {
               linePointRadius={3}
               chartHeight={420}
               showTooltip
-              apsis
-              ordinat
+              showBaselineAxis
+              showLeftAxis
             />
           </div>
         </Section>
@@ -255,8 +254,7 @@ function App() {
           title="Aylık Satış"
           showLegend
           showGrid
-          showVerticalGrid
-          showHorizontalGrid
+          showValueGrid
           showTooltip
           chartHeight={320}
         />
@@ -269,7 +267,7 @@ function App() {
           title="Satış vs Hedef + Ortalama"
           showLegend
           showGrid
-          showVerticalGrid
+          showValueGrid
           gridLineVariant="dashed"
           showTooltip
           chartHeight={340}
@@ -291,7 +289,7 @@ function App() {
           title="Satış (Detay)"
           showLegend={false}
           showGrid
-          showVerticalGrid
+          showValueGrid
           barSpacing={6}
           categorySpacing={8}
           showValues
@@ -519,8 +517,7 @@ function App() {
                   title="Vertical"
                   showLegend
                   showGrid
-                  showVerticalGrid
-                  showHorizontalGrid
+                  showValueGrid
                   chartHeight={280}
                   showTooltip
                 />
@@ -548,7 +545,7 @@ function App() {
                   title="Line Only – Two Series"
                   showLegend
                   showGrid
-                  showVerticalGrid
+                  showValueGrid
                   gridLineVariant="dashed"
                   chartHeight={280}
                   showLine

--- a/examples/demo-vite/src/BarChartsGallery.tsx
+++ b/examples/demo-vite/src/BarChartsGallery.tsx
@@ -148,41 +148,41 @@ export default function BarChartsGallery() {
   }
 
   const verticalConfigs: VCfg[] = [
-    { title: 'V1 Basic (dashed grid)', props: { data: verticalData, legends: verticalLegends, title: 'Satış & Hedef & İade', showLegend: true, showGrid: true, showHorizontalGrid: true, showTooltip: true, chartHeight: 320 } },
-    { title: 'V2 Solid Grid', props: { data: verticalData, legends: verticalLegends, gridLineVariant: 'solid', showLegend: true, showGrid: true, showHorizontalGrid: true, showTooltip: true, chartHeight: 320 } },
-    { title: 'V3 Dotted Grid', props: { data: verticalData, legends: verticalLegends, gridLineVariant: 'dotted', showLegend: true, showGrid: true, showHorizontalGrid: true, chartHeight: 320, showTooltip: true } },
+    { title: 'V1 Basic (dashed grid)', props: { data: verticalData, legends: verticalLegends, title: 'Satış & Hedef & İade', showLegend: true, showGrid: true, showValueGrid: true, showTooltip: true, chartHeight: 320 } },
+    { title: 'V2 Solid Grid', props: { data: verticalData, legends: verticalLegends, gridLineVariant: 'solid', showLegend: true, showGrid: true, showValueGrid: true, showTooltip: true, chartHeight: 320 } },
+    { title: 'V3 Dotted Grid', props: { data: verticalData, legends: verticalLegends, gridLineVariant: 'dotted', showLegend: true, showGrid: true, showValueGrid: true, chartHeight: 320, showTooltip: true } },
     { title: 'V4 Values On', props: { data: verticalData, legends: verticalLegends, showValues: true, showLegend: true, showGrid: true, chartHeight: 320, showTooltip: true } },
     { title: 'V5 Tight Bars', props: { data: verticalData, legends: verticalLegends, barSpacing: 1, categorySpacing: 6, showLegend: true, showGrid: true, chartHeight: 300, showTooltip: true } },
     { title: 'V6 Loose Bars', props: { data: verticalData, legends: verticalLegends, barSpacing: 8, categorySpacing: 14, showLegend: true, showGrid: true, chartHeight: 320, showTooltip: true } },
     { title: 'V7 Custom Scale (0..200)', props: { data: verticalData, legends: verticalLegends, scale: { min: 0, max: 200, intervals: 5 }, showLegend: true, showGrid: true, chartHeight: 340, showTooltip: true } },
-    { title: 'V8 Hide Axes (apsis=false, ordinat=false)', props: { data: verticalData, legends: verticalLegends, showLegend: true, showGrid: true, apsis: false, ordinat: false, chartHeight: 320, showTooltip: true } },
+    { title: 'V8 Hide Axes (baseline=false, left=false)', props: { data: verticalData, legends: verticalLegends, showLegend: true, showGrid: true, showBaselineAxis: false, showLeftAxis: false, chartHeight: 320, showTooltip: true } },
     { title: 'V9 ShowLine + LineSeries', props: { data: verticalData, legends: verticalLegends, showLegend: true, showGrid: true, showLine: true, lineSeries: [{ legendId: 'trend', values: [110, 130, 125, 140], dashed: false }], chartHeight: 340, showTooltip: true } },
     { title: 'V10 Line Dashed + Thick', props: { data: verticalData, legends: verticalLegends, showLegend: true, showGrid: true, showLine: true, lineWidth: 3, lineSeries: [{ legendId: 'trend', values: [100, 145, 135, 150], dashed: true }], chartHeight: 340, showTooltip: true } },
     // New: 10 categories, 3 line series
-    { title: 'V11 10 Categories + 3 Line Series', props: { data: v10Data, legends: verticalLegends, showLegend: true, showGrid: true, showHorizontalGrid: true, showLine: true, lineWidth: 2, showLinePoints: true, linePointRadius: 3, lineSeries: [
+    { title: 'V11 10 Categories + 3 Line Series', props: { data: v10Data, legends: verticalLegends, showLegend: true, showGrid: true, showValueGrid: true, showLine: true, lineWidth: 2, showLinePoints: true, linePointRadius: 3, lineSeries: [
       { legendId: 'trend', values: Array.from({ length: 10 }).map((_, i) => 70 + ((i * 9) % 90)), dashed: false },
       { legendId: 'target', values: Array.from({ length: 10 }).map((_, i) => 60 + ((i * 7) % 80)), dashed: true },
       { legendId: 'sales', values: Array.from({ length: 10 }).map((_, i) => 65 + ((i * 5) % 85)), dashed: false },
     ], chartHeight: 380, showTooltip: true } },
     // New: 10 categories, values on
-    { title: 'V12 10 Categories + Values On', props: { data: v10Data, legends: verticalLegends, showLegend: true, showGrid: true, showHorizontalGrid: true, showValues: true, chartHeight: 380, showTooltip: true } },
+    { title: 'V12 10 Categories + Values On', props: { data: v10Data, legends: verticalLegends, showLegend: true, showGrid: true, showValueGrid: true, showValues: true, chartHeight: 380, showTooltip: true } },
   ]
 
   const horizontalConfigs: HCfg[] = [
-    { title: 'H1 Basic (dashed grid)', props: { data: horizontalData, legends: horizontalLegends, title: 'Ürün Bazlı Satış', showLegend: true, showGrid: true, showTooltip: true, showVerticalGrid: true, gridLineVariant: 'dashed', apsis: true, ordinat: true } },
-    { title: 'H2 Solid Grid + Both Grids', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, showGrid: true, showTooltip: true, showVerticalGrid: true, gridLineVariant: 'solid', apsis: true, ordinat: true } },
-    { title: 'H3 Dotted Grid + Row Separators', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, showGrid: true, showTooltip: true, showVerticalGrid: false, gridLineVariant: 'dotted', apsis: true, ordinat: true } },
-    { title: 'H4 Values On', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, showValues: true, showGrid: true, showTooltip: true, showVerticalGrid: true } },
-    { title: 'H5 Bar Height 18px', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, barHeight: 18, showGrid: true, showTooltip: true, showVerticalGrid: true } },
-    { title: 'H6 Bar Height 42px', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, barHeight: 42, showGrid: true, showTooltip: true, showVerticalGrid: true } },
-    { title: 'H7 Tight Categories', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, categorySpacing: 4, showGrid: true, showTooltip: true, showVerticalGrid: true } },
-    { title: 'H8 Loose Categories', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, categorySpacing: 16, showGrid: true, showTooltip: true, showVerticalGrid: true } },
-    { title: 'H9 Three Bars + Tooltip', props: { data: horizontalDataThreeBars, legends: horizontalLegends, showLegend: true, showGrid: true, showTooltip: true, showVerticalGrid: true } },
-    { title: 'H10 Custom Scale (0..150)', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, scale: { min: 0, max: 150, intervals: 5 }, showGrid: true, showTooltip: true, showVerticalGrid: true } },
-    { title: 'H11 Hide Axes (apsis=false, ordinat=false)', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, showGrid: true, showTooltip: true, showVerticalGrid: true, apsis: false, ordinat: false } },
+    { title: 'H1 Basic (dashed grid)', props: { data: horizontalData, legends: horizontalLegends, title: 'Ürün Bazlı Satış', showLegend: true, showGrid: true, showTooltip: true, showValueGrid: true, gridLineVariant: 'dashed', showBaselineAxis: true, showLeftAxis: true } },
+    { title: 'H2 Solid Grid + Both Grids', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, showGrid: true, showTooltip: true, showValueGrid: true, gridLineVariant: 'solid', showBaselineAxis: true, showLeftAxis: true } },
+    { title: 'H3 Dotted Grid + Row Separators', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, showGrid: true, showTooltip: true, showValueGrid: false, gridLineVariant: 'dotted', showBaselineAxis: true, showLeftAxis: true } },
+    { title: 'H4 Values On', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, showValues: true, showGrid: true, showTooltip: true, showValueGrid: true } },
+    { title: 'H5 Bar Height 18px', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, barHeight: 18, showGrid: true, showTooltip: true, showValueGrid: true } },
+    { title: 'H6 Bar Height 42px', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, barHeight: 42, showGrid: true, showTooltip: true, showValueGrid: true } },
+    { title: 'H7 Tight Categories', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, categorySpacing: 4, showGrid: true, showTooltip: true, showValueGrid: true } },
+    { title: 'H8 Loose Categories', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, categorySpacing: 16, showGrid: true, showTooltip: true, showValueGrid: true } },
+    { title: 'H9 Three Bars + Tooltip', props: { data: horizontalDataThreeBars, legends: horizontalLegends, showLegend: true, showGrid: true, showTooltip: true, showValueGrid: true } },
+    { title: 'H10 Custom Scale (0..150)', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, scale: { min: 0, max: 150, intervals: 5 }, showGrid: true, showTooltip: true, showValueGrid: true } },
+    { title: 'H11 Hide Axes (baseline=false, left=false)', props: { data: horizontalData, legends: horizontalLegends, showLegend: true, showGrid: true, showTooltip: true, showValueGrid: true, showBaselineAxis: false, showLeftAxis: false } },
     // New: 10 categories, 3 bars each
-    { title: 'H12 10 Categories + 3 Bars Each (values)', props: { data: h10DataThreeBars, legends: horizontalLegends, showLegend: true, showGrid: true, showVerticalGrid: true, showValues: true, gridLineVariant: 'dashed', apsis: true, ordinat: true, showTooltip: true } },
-    { title: 'H13 10 Categories Solid Grid', props: { data: h10DataThreeBars, legends: horizontalLegends, showLegend: true, showGrid: true, showVerticalGrid: true, gridLineVariant: 'solid', apsis: true, ordinat: true, showTooltip: true } },
+    { title: 'H12 10 Categories + 3 Bars Each (values)', props: { data: h10DataThreeBars, legends: horizontalLegends, showLegend: true, showGrid: true, showValueGrid: true, showValues: true, gridLineVariant: 'dashed', showBaselineAxis: true, showLeftAxis: true, showTooltip: true } },
+    { title: 'H13 10 Categories Solid Grid', props: { data: h10DataThreeBars, legends: horizontalLegends, showLegend: true, showGrid: true, showValueGrid: true, gridLineVariant: 'solid', showBaselineAxis: true, showLeftAxis: true, showTooltip: true } },
   ]
 
   return (

--- a/src/components/ui/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/src/components/ui/HorizontalBarChart/HorizontalBarChart.tsx
@@ -169,8 +169,8 @@ function HorizontalBarChart({
   showGrid = true,
   showValueGrid = true,
   gridLineVariant = 'dashed',
-  apsis = true,
-  ordinat = true,
+  showBaselineAxis,
+  showLeftAxis,
   showValues = false,
   animated = true,
   animationDuration = 500,
@@ -216,6 +216,8 @@ function HorizontalBarChart({
 
   // Memoize container classes to prevent unnecessary re-renders
   const containerClasses = useMemo(() => {
+    const showBaseline = showBaselineAxis ?? true;
+    const showLeft = showLeftAxis ?? true;
     return unstyled
       ? classNames(
           className,
@@ -225,12 +227,12 @@ function HorizontalBarChart({
           styles.chart,
           animated && styles['chart--animated'],
           gridVariantClass,
-          !apsis && styles['chart--no-apsis'],
-          ordinat && styles['chart--ordinat'],
+          !showBaseline && styles['chart--no-apsis'],
+          showLeft && styles['chart--ordinat'],
           className,
           classes?.root
         );
-  }, [unstyled, className, classes?.root, animated, gridVariantClass, showGrid, apsis, ordinat]);
+  }, [unstyled, className, classes?.root, animated, gridVariantClass, showGrid, showBaselineAxis, showLeftAxis]);
 
   // Unified tooltip handlers using data-tooltip
   const handleEnterOrMove = useCallback((evt: React.MouseEvent<HTMLElement>) => {

--- a/src/components/ui/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/src/components/ui/HorizontalBarChart/HorizontalBarChart.tsx
@@ -11,18 +11,7 @@ import { classNames } from '@/utils/classNames';
 
 /** classNames moved to '@/utils/classNames' */
 
-/**
- * Calculates the width percentage of a bar based on its value and scale
- */
-const calculateBarWidth = (
-  value: number, 
-  min: number, 
-  max: number
-): number => {
-  const range = max - min || 1;
-  const normalizedValue = (value - min) / range;
-  return Math.max(0, Math.min(100, normalizedValue * 100));
-};
+// width percentage is now provided by useBarChartCore.getValuePercentage
 
 /**
  * Creates inline styles for animated and non-animated bars
@@ -202,6 +191,7 @@ function HorizontalBarChart({
     legendMap, 
     calculatedScale, 
     gridLines, 
+    getValuePercentage,
     tooltip, 
     bodyRef, 
     hoveredLegendId, 
@@ -291,7 +281,7 @@ function HorizontalBarChart({
                   {item.bars.map((bar, barIndex) => {
                     const legend = legendMap.get(bar.legendId);
                     const color = legend?.color || '#999999';
-                    const width = calculateBarWidth(bar.value, calculatedScale.min, calculatedScale.max);
+                    const width = getValuePercentage(bar.value);
                     const ariaLabel = legend 
                       ? `${item.category} - ${legend.label}: ${bar.value}` 
                       : `${item.category}: ${bar.value}`;

--- a/src/components/ui/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/src/components/ui/HorizontalBarChart/HorizontalBarChart.tsx
@@ -168,7 +168,7 @@ function HorizontalBarChart({
   barSpacing = 2,
   categorySpacing = 8,
   showGrid = true,
-  showVerticalGrid = true,
+  showValueGrid = true,
   gridLineVariant = 'dashed',
   apsis = true,
   ordinat = true,
@@ -255,12 +255,12 @@ function HorizontalBarChart({
       <div className={unstyled ? classes?.container : classNames(styles.chart__container, classes?.container)}>
         <div className={unstyled ? classes?.body : classNames(styles.chart__body, classes?.body)} ref={bodyRef}>
           {/* Background grid lines */}
-          <ValueGrid 
-            variant="horizontalBar" 
-            orientation="vertical" 
-            show={showGrid && showVerticalGrid} 
-            gridLines={gridLines} 
-            formatter={calculatedScale.formatter} 
+          <ValueGrid
+            variant="horizontalBar"
+            orientation="vertical"
+            show={showGrid && showValueGrid}
+            gridLines={gridLines}
+            formatter={calculatedScale.formatter}
           />
 
           {/* Chart data rows */}

--- a/src/components/ui/HorizontalBarChart/HorizontalBarChart.types.ts
+++ b/src/components/ui/HorizontalBarChart/HorizontalBarChart.types.ts
@@ -1,6 +1,7 @@
 import type React from 'react';
-import type { ChartLegendItem, GridLineVariant, BarDatum } from '@/components/ui/shared/chart/types';
+import type { BarDatum, ChartLegendItem } from '@/components/ui/shared/chart/types';
 import type { ChartScale } from '@/utils/scale';
+import type { BarChartCommonProps } from '@/components/ui/shared/bar/BarChartBase.types';
 export type { ChartLegendItem } from '@/components/ui/shared/chart/types';
 export type { ChartScale } from '@/utils/scale';
 
@@ -13,55 +14,11 @@ export interface ChartDataItem {
   bars: ReadonlyArray<ChartBar>;
 }
 
-export interface HorizontalBarChartProps {
+export interface HorizontalBarChartProps extends BarChartCommonProps<ChartBar> {
   /** Grafik verisi */
   data: ReadonlyArray<ChartDataItem>;
-  /** Explicit legend items mapping ids to labels and colors */
-  legends: ReadonlyArray<ChartLegendItem>;
-  /** X ekseni ölçek ayarları */
-  scale?: ChartScale;
-  /** Grafik başlığı */
-  title?: string;
-  /** Başlığın altında gösterilecek alt başlık */
-  subtitle?: string;
-  /** Başlığın solunda 44x44 ikon görseli */
-  iconSrc?: string;
-  /** Legend'ın gösterilip gösterilmeyeceği */
-  showLegend?: boolean;
   /** Bar yüksekliği (px) */
   barHeight?: number;
-  /** Bar'lar arası boşluk (px) */
-  barSpacing?: number;
-  /** Kategoriler arası boşluk (px) */
-  categorySpacing?: number;
-  /** Grid çizgilerinin gösterilip gösterilmeyeceği (ana anahtar) */
-  showGrid?: boolean;
-  /** Değer ızgarası görünürlüğü (x ekseni boyunca dikey çizgiler) */
-  showValueGrid?: boolean;
-  /** Grid çizgisi stili (noktalı/ düz) */
-  gridLineVariant?: GridLineVariant;
-  /** Apsis çizgisini (alt sınır) göster */
-  apsis?: boolean;
-  /** Ordinat çizgisini (sol sınır) göster */
-  ordinat?: boolean;
-  /** Değerlerin bar üzerinde gösterilip gösterilmeyeceği */
-  showValues?: boolean;
-  /** Animasyon aktif mi? */
-  animated?: boolean;
-  /** Animasyon süresi (ms) */
-  animationDuration?: number;
-  /** Ek CSS sınıfları */
-  className?: string;
-  /** Inline stil */
-  style?: React.CSSProperties;
-  /** Component ID'si */
-  id?: string;
-  /** Bar'a tıklandığında tetiklenen event */
-  onBarClick?: (data: ChartBar, categoryIndex: number, barIndex: number) => void;
-  /** Hover'da değer baloncuğunu göster */
-  showTooltip?: boolean;
-  /** Varsayılan stilleri kapatır (yalın çıktı) */
-  unstyled?: boolean;
   /** İç parça sınıfları için override */
   classes?: {
     root?: string;

--- a/src/components/ui/HorizontalBarChart/HorizontalBarChart.types.ts
+++ b/src/components/ui/HorizontalBarChart/HorizontalBarChart.types.ts
@@ -1,41 +1,16 @@
 import type React from 'react';
+import type { ChartLegendItem, GridLineVariant, BarDatum } from '@/components/ui/shared/chart/types';
+import type { ChartScale } from '@/utils/scale';
+export type { ChartLegendItem } from '@/components/ui/shared/chart/types';
+export type { ChartScale } from '@/utils/scale';
 
-export interface ChartLegendItem {
-  /** Unique id to match bars/series */
-  id: string;
-  /** Visible label shown in legend */
-  label: string;
-  /** Color used for rendering bars/series */
-  color: string;
-}
-
-export interface ChartBar {
-  /** Bar için görüntülenecek metin etiketi */
-  label: string;
-  /** Bar'ın sayısal değeri */
-  value: number;
-  /** Legend item id that provides color and legend label */
-  legendId: string;
-  /** Opsiyonel tooltip veya açıklama metni */
-  tooltip?: string;
-}
+export type ChartBar = BarDatum; // keep exported name for API compatibility
 
 export interface ChartDataItem {
   /** Y ekseninde görünecek kategori etiketi */
   category: string;
   /** Bu kategoriye ait bar'lar */
   bars: ChartBar[];
-}
-
-export interface ChartScale {
-  /** X ekseninin minimum değeri */
-  min: number;
-  /** X ekseninin maksimum değeri */
-  max: number;
-  /** X ekseninde gösterilecek aralık sayısı */
-  intervals: number;
-  /** Değerlerin formatlanması için opsiyonel formatter fonksiyonu */
-  formatter?: (value: number) => string;
 }
 
 export interface HorizontalBarChartProps {
@@ -64,7 +39,7 @@ export interface HorizontalBarChartProps {
   /** Dikey değer ızgarası (X ekseni değer çizgileri) görünürlüğü */
   showVerticalGrid?: boolean;
   /** Grid çizgisi stili (noktalı/ düz) */
-  gridLineVariant?: 'dashed' | 'solid' | 'dotted';
+  gridLineVariant?: GridLineVariant;
   /** Apsis çizgisini (alt sınır) göster */
   apsis?: boolean;
   /** Ordinat çizgisini (sol sınır) göster */

--- a/src/components/ui/HorizontalBarChart/HorizontalBarChart.types.ts
+++ b/src/components/ui/HorizontalBarChart/HorizontalBarChart.types.ts
@@ -36,8 +36,8 @@ export interface HorizontalBarChartProps {
   categorySpacing?: number;
   /** Grid çizgilerinin gösterilip gösterilmeyeceği (ana anahtar) */
   showGrid?: boolean;
-  /** Dikey değer ızgarası (X ekseni değer çizgileri) görünürlüğü */
-  showVerticalGrid?: boolean;
+  /** Değer ızgarası görünürlüğü (x ekseni boyunca dikey çizgiler) */
+  showValueGrid?: boolean;
   /** Grid çizgisi stili (noktalı/ düz) */
   gridLineVariant?: GridLineVariant;
   /** Apsis çizgisini (alt sınır) göster */

--- a/src/components/ui/HorizontalBarChart/HorizontalBarChart.types.ts
+++ b/src/components/ui/HorizontalBarChart/HorizontalBarChart.types.ts
@@ -10,14 +10,14 @@ export interface ChartDataItem {
   /** Y ekseninde görünecek kategori etiketi */
   category: string;
   /** Bu kategoriye ait bar'lar */
-  bars: ChartBar[];
+  bars: ReadonlyArray<ChartBar>;
 }
 
 export interface HorizontalBarChartProps {
   /** Grafik verisi */
-  data: ChartDataItem[];
+  data: ReadonlyArray<ChartDataItem>;
   /** Explicit legend items mapping ids to labels and colors */
-  legends: ChartLegendItem[];
+  legends: ReadonlyArray<ChartLegendItem>;
   /** X ekseni ölçek ayarları */
   scale?: ChartScale;
   /** Grafik başlığı */

--- a/src/components/ui/PieChart/PieChart.tsx
+++ b/src/components/ui/PieChart/PieChart.tsx
@@ -80,14 +80,28 @@ function PieChart({
   ), [unstyled, className, classes?.root]);
 
   // Tooltip handlers (stable)
-  const showTooltipAt = useCallback((
-    evt: React.MouseEvent<SVGPathElement, MouseEvent>,
-    content: string
-  ) => {
-    tooltip.showAtEvent(evt as unknown as React.MouseEvent, content, svgWrapRef.current);
+  // Unified tooltip handlers using data-tooltip
+  const handleEnterOrMove = useCallback((evt: React.MouseEvent<SVGElement>) => {
+    const el = evt.currentTarget as Element;
+    const content = el.getAttribute('data-tooltip') || '';
+    if (content) {
+      tooltip.showAtEvent(evt as unknown as React.MouseEvent, content, svgWrapRef.current);
+    }
   }, [tooltip]);
 
-  const hideTooltip = useCallback(() => {
+  const handleLeave = useCallback(() => {
+    tooltip.hide();
+  }, [tooltip]);
+
+  const handleFocus = useCallback((evt: React.FocusEvent<SVGElement>) => {
+    const el = evt.currentTarget as Element;
+    const content = el.getAttribute('data-tooltip') || '';
+    if (content) {
+      tooltip.showAtElement(el, content, svgWrapRef.current);
+    }
+  }, [tooltip]);
+
+  const handleBlur = useCallback(() => {
     tooltip.hide();
   }, [tooltip]);
 
@@ -123,9 +137,13 @@ function PieChart({
                     className={classNames(
                       !unstyled && isDimmed && styles['pie__slice--dimmed']
                     )}
-                    onMouseEnter={e => showTooltipAt(e, titleText)}
-                    onMouseMove={e => showTooltipAt(e, titleText)}
-                    onMouseLeave={hideTooltip}
+                    data-tooltip={titleText}
+                    tabIndex={0}
+                    onMouseEnter={handleEnterOrMove}
+                    onMouseMove={handleEnterOrMove}
+                    onMouseLeave={handleLeave}
+                    onFocus={handleFocus}
+                    onBlur={handleBlur}
                   >
                     {!showTooltip && <title>{titleText}</title>}
                   </path>

--- a/src/components/ui/PieChart/PieChart.types.ts
+++ b/src/components/ui/PieChart/PieChart.types.ts
@@ -1,13 +1,6 @@
 import type React from 'react';
-
-export interface ChartLegendItem {
-  /** Unique id to match slices */
-  id: string;
-  /** Visible label shown in legend */
-  label: string;
-  /** Slice color */
-  color: string;
-}
+import type { ChartLegendItem } from '@/components/ui/shared/chart/types';
+export type { ChartLegendItem } from '@/components/ui/shared/chart/types';
 
 export interface PieChartDatum {
   /** Numeric value for the slice */

--- a/src/components/ui/RadarChart/RadarChart.types.ts
+++ b/src/components/ui/RadarChart/RadarChart.types.ts
@@ -43,7 +43,7 @@ export interface RadarChartProps {
 	dotRadius?: number;
 	/** Stroke width for series outline */
 	strokeWidth?: number;
-	/** Default fill opacity for series area (0..1) */
+	/** Default fill opacity for series area (0..1). When the legend item has `fillOpacity`, it takes precedence. */
 	fillOpacity?: number;
 	/** Square SVG viewport size in px (it will scale responsively) */
 	size?: number;

--- a/src/components/ui/RadarChart/RadarChart.types.ts
+++ b/src/components/ui/RadarChart/RadarChart.types.ts
@@ -1,17 +1,9 @@
 import type React from 'react';
 import type { ChartLegendItem, GridLineVariant } from '@/components/ui/shared/chart/types';
+import type { ChartScale } from '@/utils/scale';
 export type { ChartLegendItem } from '@/components/ui/shared/chart/types';
 
-export interface RadarChartScale {
-	/** Minimum value across all axes */
-	min: number;
-	/** Maximum value across all axes */
-	max: number;
-	/** Number of concentric grid levels (rings/polygons) */
-	intervals: number;
-	/** Optional formatter for scale labels */
-	formatter?: (value: number) => string;
-}
+export type RadarChartScale = ChartScale;
 
 // ChartLegendItem unified in shared types (with optional fillOpacity)
 

--- a/src/components/ui/RadarChart/RadarChart.types.ts
+++ b/src/components/ui/RadarChart/RadarChart.types.ts
@@ -1,4 +1,6 @@
 import type React from 'react';
+import type { ChartLegendItem, GridLineVariant } from '@/components/ui/shared/chart/types';
+export type { ChartLegendItem } from '@/components/ui/shared/chart/types';
 
 export interface RadarChartScale {
 	/** Minimum value across all axes */
@@ -11,16 +13,7 @@ export interface RadarChartScale {
 	formatter?: (value: number) => string;
 }
 
-export interface ChartLegendItem {
-	/** Unique id to match series */
-	id: string;
-	/** Visible label shown in legend */
-	label: string;
-	/** Color used for stroke and fill */
-	color: string;
-	/** Optional custom fill opacity for this series (0..1) */
-	fillOpacity?: number;
-}
+// ChartLegendItem unified in shared types (with optional fillOpacity)
 
 export interface RadarChartSeries {
 	/** Values for each axis, in the same order as axes */
@@ -53,7 +46,7 @@ export interface RadarChartProps {
 	/** Controls axis labels visibility */
 	showAxisLabels?: boolean;
 	/** Grid line variant */
-	gridLineVariant?: 'dashed' | 'solid' | 'dotted';
+	gridLineVariant?: GridLineVariant;
 	/** Radius of the small dots at each value point */
 	dotRadius?: number;
 	/** Stroke width for series outline */

--- a/src/components/ui/VerticalBarChart/VerticalBarChart.tsx
+++ b/src/components/ui/VerticalBarChart/VerticalBarChart.tsx
@@ -285,8 +285,8 @@ function VerticalBarChart({
   barSpacing = 2,
   categorySpacing = 8,
   showGrid = true,
-  showHorizontalGrid = true,
-  showVerticalGrid = false,
+  showValueGrid = true,
+  showCategoryGrid = false,
   gridLineVariant = 'dashed',
   showValues = false,
   animated = true,
@@ -371,8 +371,8 @@ function VerticalBarChart({
 
       <div className={unstyled ? classes?.container : classNames(styles.chart__container, classes?.container)}>
         <div className={unstyled ? classes?.body : classNames(styles.chart__body, classes?.body)}>
-          <ValueGrid variant="verticalBar" orientation="horizontal" show={showGrid && showHorizontalGrid} gridLines={gridLines} formatter={calculatedScale.formatter} />
-          <CategoryGrid show={showGrid && showVerticalGrid} categoryCount={data.length} categorySpacing={categorySpacing} apsis={showBaselineAxis} ordinat={showLeftAxis} />
+          <ValueGrid variant="verticalBar" orientation="horizontal" show={showGrid && showValueGrid} gridLines={gridLines} formatter={calculatedScale.formatter} />
+          <CategoryGrid show={showGrid && showCategoryGrid} categoryCount={data.length} categorySpacing={categorySpacing} apsis={showBaselineAxis} ordinat={showLeftAxis} />
 
           <div
             ref={columnsRef}

--- a/src/components/ui/VerticalBarChart/VerticalBarChart.tsx
+++ b/src/components/ui/VerticalBarChart/VerticalBarChart.tsx
@@ -136,6 +136,7 @@ const renderLineLayer = (
               fill="none"
               strokeDasharray={series.dashed ? '6 4' : undefined}
               className={!unstyled && isDimmed ? styles['chart__line--dimmed'] : undefined}
+              aria-hidden="true"
             />
             {showLinePoints && points.map((p, idx) => {
               const categoryLabel = data[idx]?.category ?? `${idx + 1}`;
@@ -294,8 +295,8 @@ function VerticalBarChart({
   lineWidth = 2,
   showLinePoints = true,
   linePointRadius = 4,
-  apsis = true,
-  ordinat = true,
+  showBaselineAxis,
+  showLeftAxis,
   showTooltip = false,
   unstyled = false,
   style,
@@ -303,9 +304,9 @@ function VerticalBarChart({
 }: VerticalBarChartProps) {
   // ==================== HOOKS & STATE ====================
   
-  // Aliases for readability
-  const showBaselineAxis = apsis;
-  const showLeftAxis = ordinat;
+  // Resolve standardized axis props
+  const showBaselineAxisResolved = (showBaselineAxis ?? true);
+  const showLeftAxisResolved = (showLeftAxis ?? true);
 
   const reactId = useId();
   const chartId = id ?? reactId;
@@ -403,7 +404,7 @@ function VerticalBarChart({
       <div className={unstyled ? classes?.container : classNames(styles.chart__container, classes?.container)}>
         <div className={unstyled ? classes?.body : classNames(styles.chart__body, classes?.body)}>
           <ValueGrid variant="verticalBar" orientation="horizontal" show={showGrid && showValueGrid} gridLines={gridLines} formatter={calculatedScale.formatter} />
-          <CategoryGrid show={showGrid && showCategoryGrid} categoryCount={data.length} categorySpacing={categorySpacing} apsis={showBaselineAxis} ordinat={showLeftAxis} />
+          <CategoryGrid show={showGrid && showCategoryGrid} categoryCount={data.length} categorySpacing={categorySpacing} showBaselineAxis={showBaselineAxisResolved} showLeftAxis={showLeftAxisResolved} />
 
           <div
             ref={columnsRef}

--- a/src/components/ui/VerticalBarChart/VerticalBarChart.tsx
+++ b/src/components/ui/VerticalBarChart/VerticalBarChart.tsx
@@ -14,7 +14,7 @@ import type {
   VerticalBarChartLineSeries,
   ChartLegendItem,
 } from './VerticalBarChart.types';
-import type { useTooltip } from '@/hooks/useTooltip';
+import { useTooltip } from '@/hooks/useTooltip';
 import { useBarChartCore } from '../shared/bar/useBarChartCore';
 import { classNames } from '@/utils/classNames';
 
@@ -129,7 +129,7 @@ const renderLineLayer = (
           acc + (i === 0 ? `M ${p.x} ${p.y}` : ` L ${p.x} ${p.y}`)
         ), '');
 
-        const legend = (legendMap as Map<string, { id: string; label: string; color: string }>).get(series.legendId);
+        const legend = legendMap.get(series.legendId);
         const strokeColor = legend?.color || '#888888';
         const isDimmed = hoveredLegendId !== null && series.legendId !== hoveredLegendId;
 
@@ -198,7 +198,7 @@ const renderBars = (
     >
       {item.bars.map((bar, barIndex) => {
         const height = getValuePercentage(bar.value);
-        const legend = (legendMap as Map<string, { id: string; label: string; color: string }>).get(bar.legendId);
+        const legend = (legendMap as Map<string, ChartLegendItem>).get(bar.legendId);
         const color = legend?.color || '#999999';
 
         const baseStyle: React.CSSProperties & {
@@ -430,7 +430,7 @@ function VerticalBarChart({
         show={showLegend}
         items={barLegends}
         lineItems={lineSeries}
-        legendMap={legendMap as unknown as Map<string, { id: string; label: string; color: string }>}
+        legendMap={legendMap as unknown as Map<string, ChartLegendItem>}
         onEnter={(id) => onLegendEnter(id)}
         onLeave={() => onLegendLeave()}
       />

--- a/src/components/ui/VerticalBarChart/VerticalBarChart.types.ts
+++ b/src/components/ui/VerticalBarChart/VerticalBarChart.types.ts
@@ -1,6 +1,7 @@
 import type React from 'react';
 import type { ChartLegendItem, GridLineVariant, BarDatum } from '@/components/ui/shared/chart/types';
 import type { ChartScale } from '@/utils/scale';
+import type { BarChartCommonProps } from '@/components/ui/shared/bar/BarChartBase.types';
 export type VerticalBarChartScale = ChartScale;
 
 export type VerticalBarChartBar = BarDatum; // keep exported name for API compatibility
@@ -22,49 +23,13 @@ export interface VerticalBarChartLineSeries {
   dashed?: boolean;
 }
 
-  export interface VerticalBarChartProps {
+export interface VerticalBarChartProps extends BarChartCommonProps<VerticalBarChartBar> {
   /** Grafik verisi */
   data: ReadonlyArray<VerticalBarChartDataItem>;
-  /** Explicit legend items mapping ids to labels and colors */
-  legends: ReadonlyArray<ChartLegendItem>;
-  /** X ekseni ölçek ayarları */
-  scale?: VerticalBarChartScale;
-  /** Grafik başlığı */
-  title?: string;
-  /** Başlığın altında gösterilecek alt başlık */
-  subtitle?: string;
-  /** Başlığın solunda 44x44 ikon görseli */
-  iconSrc?: string;
-  /** Legend'ın gösterilip gösterilmeyeceği */
-  showLegend?: boolean;
-  /** Aynı grup içindeki bar'lar arası boşluk (px) */
-  barSpacing?: number;
-  /** Gruplar (kategoriler) arası yatay boşluk (px) */
-  categorySpacing?: number;
-  /** Grid çizgilerinin genel olarak gösterilip gösterilmeyeceği (ana anahtar) */
-  showGrid?: boolean;
-  /** Değer ızgarası (yatay çizgiler) görünürlüğü */
-  showValueGrid?: boolean;
   /** Kategori ızgarası (dikey kolonlar) görünürlüğü */
   showCategoryGrid?: boolean;
-  /** Grid çizgisi stili (noktalı/ düz) */
-  gridLineVariant?: GridLineVariant;
-  /** Değerlerin bar üzerinde gösterilip gösterilmeyeceği */
-  showValues?: boolean;
-  /** Animasyon aktif mi? */
-  animated?: boolean;
-  /** Animasyon süresi (ms) */
-  animationDuration?: number;
   /** Grafik dikey alan yüksekliği (px) */
   chartHeight?: number;
-  /** Ek CSS sınıfları */
-  className?: string;
-  /** Inline stil */
-  style?: React.CSSProperties;
-  /** Component ID'si */
-  id?: string;
-  /** Bar'a tıklandığında tetiklenen event */
-  onBarClick?: (data: VerticalBarChartBar, categoryIndex: number, barIndex: number) => void;
   /** Çizgi grafiğinin gösterilip gösterilmeyeceği */
   showLine?: boolean;
   /** Bir veya birden fazla çizgi serisi */
@@ -75,14 +40,6 @@ export interface VerticalBarChartLineSeries {
   showLinePoints?: boolean;
   /** Nokta yarıçapı (px) */
   linePointRadius?: number;
-  /** Apsis çizgisini (alt sınır) göster */
-  apsis?: boolean;
-  /** Ordinat çizgisini (sol sınır) göster */
-  ordinat?: boolean;
-  /** Hover'da değer baloncuğunu göster */
-  showTooltip?: boolean;
-  /** Varsayılan stilleri kapatır (yalın çıktı) */
-  unstyled?: boolean;
   /** İç parça sınıfları için override */
   classes?: {
     root?: string;

--- a/src/components/ui/VerticalBarChart/VerticalBarChart.types.ts
+++ b/src/components/ui/VerticalBarChart/VerticalBarChart.types.ts
@@ -10,12 +10,12 @@ export interface VerticalBarChartDataItem {
   /** Y ekseninde görünecek kategori etiketi */
   category: string;
   /** Bu kategoriye ait bar'lar */
-  bars: VerticalBarChartBar[];
+  bars: ReadonlyArray<VerticalBarChartBar>;
 }
 
 export interface VerticalBarChartLineSeries {
   /** Kategoriler ile aynı sırada olacak şekilde değerler dizisi */
-  values: number[];
+  values: ReadonlyArray<number>;
   /** Legend mapping id for color/label */
   legendId: string;
   /** Kesik çizgi için */

--- a/src/components/ui/VerticalBarChart/VerticalBarChart.types.ts
+++ b/src/components/ui/VerticalBarChart/VerticalBarChart.types.ts
@@ -1,41 +1,16 @@
 import type React from 'react';
+import type { ChartLegendItem, GridLineVariant, BarDatum } from '@/components/ui/shared/chart/types';
+import type { ChartScale } from '@/utils/scale';
+export type VerticalBarChartScale = ChartScale;
 
-export interface ChartLegendItem {
-  /** Unique id to match bars/series */
-  id: string;
-  /** Visible label shown in legend */
-  label: string;
-  /** Color used for rendering bars/series */
-  color: string;
-}
-
-export interface VerticalBarChartBar {
-  /** Bar için görüntülenecek metin etiketi */
-  label: string;
-  /** Bar'ın sayısal değeri */
-  value: number;
-  /** Legend item id that provides color and legend label */
-  legendId: string;
-  /** Opsiyonel tooltip veya açıklama metni */
-  tooltip?: string;
-}
+export type VerticalBarChartBar = BarDatum; // keep exported name for API compatibility
+export type { ChartLegendItem } from '@/components/ui/shared/chart/types';
 
 export interface VerticalBarChartDataItem {
   /** Y ekseninde görünecek kategori etiketi */
   category: string;
   /** Bu kategoriye ait bar'lar */
   bars: VerticalBarChartBar[];
-}
-
-export interface VerticalBarChartScale {
-  /** Y ekseninin minimum değeri */
-  min: number;
-  /** Y ekseninin maksimum değeri */
-  max: number;
-  /** Y ekseninde gösterilecek aralık sayısı */
-  intervals: number;
-  /** Değerlerin formatlanması için opsiyonel formatter fonksiyonu */
-  formatter?: (value: number) => string;
 }
 
 export interface VerticalBarChartLineSeries {
@@ -73,7 +48,7 @@ export interface VerticalBarChartLineSeries {
   /** Dikey grid çizgilerinin gösterilip gösterilmeyeceği */
   showVerticalGrid?: boolean;
   /** Grid çizgisi stili (noktalı/ düz) */
-  gridLineVariant?: 'dashed' | 'solid' | 'dotted';
+  gridLineVariant?: GridLineVariant;
   /** Değerlerin bar üzerinde gösterilip gösterilmeyeceği */
   showValues?: boolean;
   /** Animasyon aktif mi? */

--- a/src/components/ui/VerticalBarChart/VerticalBarChart.types.ts
+++ b/src/components/ui/VerticalBarChart/VerticalBarChart.types.ts
@@ -43,10 +43,10 @@ export interface VerticalBarChartLineSeries {
   categorySpacing?: number;
   /** Grid çizgilerinin genel olarak gösterilip gösterilmeyeceği (ana anahtar) */
   showGrid?: boolean;
-  /** Yatay grid çizgilerinin gösterilip gösterilmeyeceği */
-  showHorizontalGrid?: boolean;
-  /** Dikey grid çizgilerinin gösterilip gösterilmeyeceği */
-  showVerticalGrid?: boolean;
+  /** Değer ızgarası (yatay çizgiler) görünürlüğü */
+  showValueGrid?: boolean;
+  /** Kategori ızgarası (dikey kolonlar) görünürlüğü */
+  showCategoryGrid?: boolean;
   /** Grid çizgisi stili (noktalı/ düz) */
   gridLineVariant?: GridLineVariant;
   /** Değerlerin bar üzerinde gösterilip gösterilmeyeceği */

--- a/src/components/ui/shared/bar/BarChartBase.types.ts
+++ b/src/components/ui/shared/bar/BarChartBase.types.ts
@@ -1,0 +1,63 @@
+import type React from 'react';
+import type { ChartLegendItem, GridLineVariant, BarDatum } from '@/components/ui/shared/chart/types';
+import type { ChartScale } from '@/utils/scale';
+
+/** Common props shared by Horizontal and Vertical bar charts */
+export interface BarChartCommonProps<B extends BarDatum = BarDatum> {
+  /** Explicit legend items mapping ids to labels and colors */
+  legends: ReadonlyArray<ChartLegendItem>;
+  /** Scale configuration for numeric domain */
+  scale?: ChartScale;
+
+  /** Header: main title */
+  title?: string;
+  /** Header: subtitle under the title */
+  subtitle?: string;
+  /** Optional 44x44 icon path shown left of the title */
+  iconSrc?: string;
+  /** Controls legend visibility */
+  showLegend?: boolean;
+
+  /** Space between bars in the same category (px) */
+  barSpacing?: number;
+  /** Space between categories (px) */
+  categorySpacing?: number;
+
+  /** Master toggle for background grids */
+  showGrid?: boolean;
+  /** Value grid visibility (orientation depends on chart) */
+  showValueGrid?: boolean;
+  /** Grid line style */
+  gridLineVariant?: GridLineVariant;
+
+  /** Show numeric values on bars */
+  showValues?: boolean;
+  /** Animate bars */
+  animated?: boolean;
+  /** Animation duration in ms */
+  animationDuration?: number;
+
+  /** Axis helpers */
+  showBaselineAxis?: boolean;
+  showLeftAxis?: boolean;
+
+  /** Hover tooltip */
+  showTooltip?: boolean;
+
+  /** Extra class names and style */
+  className?: string;
+  style?: React.CSSProperties;
+  id?: string;
+
+  /** Bar click handler */
+  onBarClick?: (data: B, categoryIndex: number, barIndex: number) => void;
+
+  /** Disable default styles */
+  unstyled?: boolean;
+  /** Per-part class overrides (keys vary per chart) */
+  classes?: Record<string, string | undefined>;
+
+}
+
+export type { ChartLegendItem, GridLineVariant, BarDatum };
+export type { ChartScale };

--- a/src/components/ui/shared/chart/parts/CategoryGrid.tsx
+++ b/src/components/ui/shared/chart/parts/CategoryGrid.tsx
@@ -2,14 +2,14 @@ import stylesV from '@/components/ui/VerticalBarChart/VerticalBarChart.module.cs
 import type { CategoryGridProps } from './CategoryGrid.types';
 import { classNames } from '@/utils/classNames';
 
-export function CategoryGrid({ show, categoryCount, categorySpacing, apsis, ordinat }: CategoryGridProps) {
+export function CategoryGrid({ show, categoryCount, categorySpacing, showBaselineAxis, showLeftAxis }: CategoryGridProps) {
 	if (!show) return null;
 	return (
 		<div
 			className={classNames(
 				stylesV.chart__vgrid,
-				apsis && stylesV['chart__vgrid--apsis'],
-				ordinat && stylesV['chart__vgrid--ordinat']
+				showBaselineAxis && stylesV['chart__vgrid--apsis'],
+				showLeftAxis && stylesV['chart__vgrid--ordinat']
 			)}
 			aria-hidden="true"
 			style={{ gap: `${categorySpacing}px` }}

--- a/src/components/ui/shared/chart/parts/CategoryGrid.types.ts
+++ b/src/components/ui/shared/chart/parts/CategoryGrid.types.ts
@@ -2,6 +2,6 @@ export type CategoryGridProps = {
 	show: boolean;
 	categoryCount: number;
 	categorySpacing: number;
-	apsis?: boolean;
-	ordinat?: boolean;
+	showBaselineAxis?: boolean; // formerly apsis
+	showLeftAxis?: boolean;     // formerly ordinat
 }; 

--- a/src/components/ui/shared/chart/parts/Legend.types.ts
+++ b/src/components/ui/shared/chart/parts/Legend.types.ts
@@ -1,10 +1,6 @@
 export type LegendVariant = 'vertical' | 'horizontal' | 'pie' | 'radar';
-
-export type SharedLegendItem = {
-	id: string;
-	label: string;
-	color: string;
-};
+import type { ChartLegendItem } from '@/components/ui/shared/chart/types';
+export type SharedLegendItem = ChartLegendItem;
 
 export type SharedLineLegendItem = {
 	legendId: string;

--- a/src/components/ui/shared/chart/types.ts
+++ b/src/components/ui/shared/chart/types.ts
@@ -1,0 +1,20 @@
+// Shared chart types to unify props and avoid duplication across components
+
+export type GridLineVariant = 'dashed' | 'solid' | 'dotted';
+
+export type ChartLegendItem = {
+  id: string;
+  label: string;
+  color: string;
+  /** Optional opacity for filled areas (used by Radar); ignored elsewhere */
+  fillOpacity?: number;
+};
+
+// Minimal bar datum used by bar-like charts; optional label for flexibility
+export type BarDatum = {
+  value: number;
+  legendId: string;
+  tooltip?: string;
+  label?: string;
+};
+

--- a/src/hooks/useTooltip.ts
+++ b/src/hooks/useTooltip.ts
@@ -26,5 +26,18 @@ export function useTooltip(options: { enabled: boolean }): TooltipApi {
 		setState(prev => ({ ...prev, visible: false }));
 	}, [options.enabled]);
 
-	return { state, showAtEvent, hide };
-} 
+	const showAtElement = React.useCallback((el: Element, content: string, bodyEl?: HTMLDivElement | null) => {
+		if (!options.enabled || !bodyEl) return;
+		try {
+			const bodyRect = bodyEl.getBoundingClientRect();
+			const elRect = el.getBoundingClientRect();
+			const x = Math.max(0, Math.min(elRect.left - bodyRect.left + elRect.width / 2, bodyRect.width - 8));
+			const y = Math.max(0, Math.min(elRect.top - bodyRect.top + elRect.height / 2, bodyRect.height - 8));
+			setState({ visible: true, x, y, content });
+		} catch {
+			// no-op
+		}
+	}, [options.enabled]);
+
+	return { state, showAtEvent, showAtElement, hide };
+}

--- a/src/hooks/useTooltip.types.ts
+++ b/src/hooks/useTooltip.types.ts
@@ -14,5 +14,10 @@ export type TooltipApi = {
 		content: string,
 		bodyEl?: HTMLDivElement | null
 	) => void;
+	showAtElement: (
+		el: Element,
+		content: string,
+		bodyEl?: HTMLDivElement | null
+	) => void;
 	hide: () => void;
-}; 
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ export { default as HorizontalBarChart } from "./components/ui/HorizontalBarChar
 export type {
   HorizontalBarChartProps,
   ChartBar,
-  ChartLegendItem as HorizontalBarChartLegendItem,
 } from "./components/ui/HorizontalBarChart/HorizontalBarChart.types";
+export type { ChartLegendItem as HorizontalBarChartLegendItem } from "./components/ui/shared/chart/types";
 
 export { default as VerticalBarChart } from "./components/ui/VerticalBarChart/VerticalBarChart";
 export type {
@@ -11,23 +11,26 @@ export type {
   VerticalBarChartDataItem,
   VerticalBarChartScale,
   VerticalBarChartLineSeries,
-  ChartLegendItem as VerticalBarChartLegendItem,
 } from "./components/ui/VerticalBarChart/VerticalBarChart.types";
+export type { ChartLegendItem as VerticalBarChartLegendItem } from "./components/ui/shared/chart/types";
 
 export { default as PieChart } from "./components/ui/PieChart/PieChart";
 export type {
   PieChartProps,
   PieChartDatum,
-  ChartLegendItem as PieChartLegendItem,
 } from "./components/ui/PieChart/PieChart.types";
+export type { ChartLegendItem as PieChartLegendItem } from "./components/ui/shared/chart/types";
 
 export { default as RadarChart } from "./components/ui/RadarChart/RadarChart";
 export type {
   RadarChartProps,
   RadarChartSeries,
   RadarChartScale,
-  ChartLegendItem as RadarChartLegendItem,
 } from "./components/ui/RadarChart/RadarChart.types";
+export type { ChartLegendItem as RadarChartLegendItem } from "./components/ui/shared/chart/types";
+
+// Generic shared types
+export type { ChartLegendItem } from "./components/ui/shared/chart/types";
 
 export { ChartHeader } from "./components/ui/shared/chart/parts/ChartHeader";
 export { Legend } from "./components/ui/shared/chart/parts/Legend";


### PR DESCRIPTION
Updates `classes` prop type definitions for `BarChart`, `PieChart`, and `RadarChart` components to provide more specific keys for custom CSS classes, enhancing type safety and guiding usage.

Makes the `label` property in `ChartBar` optional. Extends `ChartLegendItem` with an optional `fillOpacity` property and consolidates `RadarChart`'s legend item to use this shared type, reducing redundancy.

Removes decorative emojis from README section headers for a cleaner aesthetic.

## Description

Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

## Related issues

Fixes #

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies shared chart types and bar props, renames grid/axis props (showValueGrid/showCategoryGrid, showBaselineAxis/showLeftAxis), standardizes tooltip/keyboard handling, and updates components, examples, and docs accordingly.
> 
> - **Core/Types**:
>   - Add shared types (`ChartLegendItem` with optional `fillOpacity`, `BarDatum`, `GridLineVariant`) and `BarChartCommonProps` in `shared/chart/types` and `shared/bar/BarChartBase.types`.
>   - Make `ChartBar.label` optional; adopt shared legend/type exports across `HorizontalBarChart`, `VerticalBarChart`, `PieChart`, `RadarChart`, and `src/index.ts`.
> - **Props Renames/Standardization**:
>   - Replace `showVerticalGrid`/`showHorizontalGrid` with `showValueGrid` (and `showCategoryGrid` for vertical bars).
>   - Replace `apsis`/`ordinat` with `showBaselineAxis`/`showLeftAxis` (including `CategoryGrid` props).
> - **Tooltip & A11y**:
>   - Unify tooltip API with `data-tooltip`, add `showAtElement` and focus/blur handlers for keyboard accessibility across Pie/Radar/Bar charts.
> - **Components**:
>   - HorizontalBar: use `useBarChartCore.getValuePercentage`; refactor tooltip handlers and axis/grid usage.
>   - VerticalBar: compute heights via shared percentage; add category grid toggle; refactor line layer and tooltip handlers; minor legend typing fixes.
>   - Radar/Pie: switch to data-attribute tooltip handlers; support focusable elements; Radar honors legend `fillOpacity`.
> - **Examples**:
>   - Update demos to new prop names (`showValueGrid`, `showBaselineAxis`, `showLeftAxis`, `showCategoryGrid`).
> - **Docs**:
>   - README: remove emojis from headings; update API tables to reflect new props and refined `classes` typings; add shared props section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f160651686ceb94f5c54141b805148cd4ebb774. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->